### PR TITLE
Fixing tf_serving functions base image

### DIFF
--- a/tf1_serving/function.yaml
+++ b/tf1_serving/function.yaml
@@ -1,7 +1,7 @@
 kind: remote
 metadata:
   name: tf1-serving
-  hash: 7da4745b886029728656765e4dcd7311735ddf6f
+  hash: adf7287e30fd7c44103ad364b909f169df9225d1
   project: default
   labels:
     author: yaronh
@@ -39,12 +39,12 @@ spec:
     kind: nuclio:serving
     metadata:
       annotations:
-        nuclio.io/generated_by: function generated from 30-08-2020
+        nuclio.io/generated_by: function generated from 01-09-2020
       labels: {}
       name: tf1-serving
     spec:
       build:
-        baseImage: mlrun/ml-serving:0.4.7-py36
+        baseImage: mlrun/mlrun
         commands:
         - pip install tensorflow==1.14 keras==2.3.1
         - pip install requests pillow

--- a/tf1_serving/tf1_serving.ipynb
+++ b/tf1_serving/tf1_serving.ipynb
@@ -69,7 +69,7 @@
      "text": [
       "%nuclio: setting kind to 'nuclio:serving'\n",
       "%nuclio: setting 'MODEL_CLASS' environment variable\n",
-      "%nuclio: setting spec.build.baseImage to 'mlrun/ml-serving:0.4.7-py36'\n"
+      "%nuclio: setting spec.build.baseImage to 'mlrun/mlrun'\n"
      ]
     }
    ],
@@ -80,7 +80,7 @@
     "# tensorflow version 1 requires a different version of python than \n",
     "# the default (3.7), so we override the default tag here:\n",
     "\n",
-    "%nuclio config spec.build.baseImage = \"mlrun/ml-serving:0.4.7-py36\""
+    "%nuclio config spec.build.baseImage = \"mlrun/mlrun\""
    ]
   },
   {

--- a/tf2_serving/function.yaml
+++ b/tf2_serving/function.yaml
@@ -1,7 +1,7 @@
 kind: remote
 metadata:
   name: tf2-serving
-  hash: 36cdd32aae68d2603712322f0dbd4f2263b7e760
+  hash: 134293b94996e74275d90546f8d4ef96198af679
   project: default
   labels:
     author: yaronh
@@ -39,12 +39,12 @@ spec:
     kind: nuclio:serving
     metadata:
       annotations:
-        nuclio.io/generated_by: function generated from 30-08-2020
+        nuclio.io/generated_by: function generated from 01-09-2020
       labels: {}
       name: tf2-serving
     spec:
       build:
-        baseImage: mlrun/ml-serving
+        baseImage: mlrun/mlrun
         commands:
         - pip install tensorflow>=2.1
         - pip install requests pillow

--- a/tf2_serving/tf2_serving.ipynb
+++ b/tf2_serving/tf2_serving.ipynb
@@ -69,7 +69,7 @@
      "text": [
       "%nuclio: setting kind to 'nuclio:serving'\n",
       "%nuclio: setting 'MODEL_CLASS' environment variable\n",
-      "%nuclio: setting spec.build.baseImage to 'mlrun/ml-serving'\n"
+      "%nuclio: setting spec.build.baseImage to 'mlrun/mlrun'\n"
      ]
     }
    ],
@@ -79,7 +79,7 @@
     "\n",
     "# tensorflow 2 use the default serving image (or the mlrun/ml-models for a faster build)\n",
     "\n",
-    "%nuclio config spec.build.baseImage = \"mlrun/ml-serving\""
+    "%nuclio config spec.build.baseImage = \"mlrun/mlrun\""
    ]
   },
   {


### PR DESCRIPTION
https://github.com/mlrun/functions/pull/65 - mistakenly changed tf1_serving and tf2_serving base image from `mlrun/mlrun` to `mlrun/ml-serving` changed it back (in the function.yaml) and did the needed changes so that the notebook will output the right yaml