### PR TITLE
[auto_trainer] Bug fix in evaluate handler

### DIFF
--- a/auto_trainer/auto_trainer.py
+++ b/auto_trainer/auto_trainer.py
@@ -247,6 +247,7 @@ def evaluate(
     # Parsing label_columns:
     parsed_label_columns = []
     if label_columns:
+        label_columns = list(label_columns)
         for lc in label_columns:
             if fs.common.feature_separator in lc:
                 feature_set_name, label_name, alias = fs.common.parse_feature_string(lc)


### PR DESCRIPTION
fixed bug when a `string` is provided to `label_columns` parameter in the `evaluate` handler