### PR TITLE
[Hub] Hide functions that uses mlutils

### DIFF
--- a/coxph_trainer/item.yaml
+++ b/coxph_trainer/item.yaml
@@ -6,7 +6,7 @@ description: cox proportional hazards, kaplan meier plots
 doc: ''
 example: coxph_trainer.ipynb
 generationDate: 2022-08-28:17-25
-hidden: false
+hidden: true
 icon: ''
 labels:
   author: yjb

--- a/describe_dask/item.yaml
+++ b/describe_dask/item.yaml
@@ -5,7 +5,7 @@ description: describe and visualizes dataset stats
 doc: ''
 example: describe_dask.ipynb
 generationDate: 2022-08-28:17-25
-hidden: false
+hidden: true
 icon: ''
 labels:
   author: Iguazio

--- a/feature_selection/item.yaml
+++ b/feature_selection/item.yaml
@@ -6,7 +6,7 @@ description: Select features through multiple Statistical and Model filters
 doc: ''
 example: feature_selection.ipynb
 generationDate: 2022-08-28:17-25
-hidden: false
+hidden: true
 icon: ''
 labels:
   author: orz

--- a/sklearn_classifier/item.yaml
+++ b/sklearn_classifier/item.yaml
@@ -6,7 +6,7 @@ description: train any classifier using scikit-learn's API
 doc: ''
 example: sklearn_classifier.ipynb
 generationDate: 2022-08-28:17-25
-hidden: false
+hidden: true
 icon: ''
 labels:
   author: yjb

--- a/sklearn_classifier_dask/item.yaml
+++ b/sklearn_classifier_dask/item.yaml
@@ -6,7 +6,7 @@ description: train any classifier using scikit-learn's API over Dask
 doc: ''
 example: sklearn_classifier_dask.ipynb
 generationDate: 2022-08-28:17-25
-hidden: false
+hidden: true
 icon: ''
 labels:
   author: yjb

--- a/test_classifier/item.yaml
+++ b/test_classifier/item.yaml
@@ -6,7 +6,7 @@ description: test a classifier using held-out or new data
 doc: README.md
 example: test_classifier.ipynb
 generationDate: 2022-08-28:17-25
-hidden: false
+hidden: true
 icon: ''
 labels:
   author: yjb

--- a/xgb_custom/item.yaml
+++ b/xgb_custom/item.yaml
@@ -7,7 +7,7 @@ description: simulate data with outliers.
 doc: ''
 example: xgb_custom.ipynb
 generationDate: 2022-08-28:17-25
-hidden: false
+hidden: true
 icon: ''
 labels:
   author: Daniel

--- a/xgb_test/item.yaml
+++ b/xgb_test/item.yaml
@@ -5,7 +5,7 @@ description: Test one or more classifier models against held-out dataset.
 doc: ''
 example: xgb_test.ipynb
 generationDate: 2022-08-28:17-25
-hidden: false
+hidden: true
 icon: ''
 labels:
   author: Daniel

--- a/xgb_trainer/item.yaml
+++ b/xgb_trainer/item.yaml
@@ -5,7 +5,7 @@ description: train multiple model types using xgboost.
 doc: ''
 example: xgb_trainer.ipynb
 generationDate: 2022-08-28:17-25
-hidden: false
+hidden: true
 icon: ''
 labels:
   author: Daniel


### PR DESCRIPTION
The following functions are now hidden:

- `coxph_trainer`
- `describe_dask`
- `feature_selection`
- `sklearn_classifier`
- `sklearn_classifier_dask`
- `xgb_trainer`
- `xgb_custom`
- `xgb_test`
- `test_classifier`