### PR TITLE
[onnx_utils][build] Added `wrapt` limit to requirements and improved installing requirements process

### DIFF
--- a/cli/test_suite.py
+++ b/cli/test_suite.py
@@ -30,7 +30,6 @@ from cli.helpers import (
     install_python,
     install_requirements,
     get_item_yaml_values,
-    get_txt_requirements
 )
 from cli.path_iterator import PathIterator
 
@@ -233,10 +232,8 @@ class TestPY(TestSuite):
     def run(self, path: Union[str, Path]):
         print("PY run path {}".format(path))
         install_python(path)
-        txt_requirements = get_txt_requirements(path)
         item_requirements = list(get_item_yaml_values(path, 'requirements')['requirements'])
-        print(["pytest"] + item_requirements + txt_requirements)
-        install_requirements(path, ["pytest"] + item_requirements + txt_requirements)
+        install_requirements(path, ["pytest", "mlrun"] + item_requirements)
         click.echo(f"Running tests for {path}...")
         completed_process: CompletedProcess = subprocess.run(
             f"cd {path} ; pipenv run python -m pytest",

--- a/onnx_utils/requirements.txt
+++ b/onnx_utils/requirements.txt
@@ -9,3 +9,4 @@ onnxmltools~=1.9.0
 tf2onnx~=1.9.0
 mlrun
 plotly~=5.4.0
+wrapt<1.15.0 # wrapt==1.15.0 fails tensorflow 2.7 Todo: please remove when updating tensorflow


### PR DESCRIPTION
1. Added section to install the `requirements.txt` directly from file instead of parsing from it.
2. Added `wrapt` limit to `onnx_utils` requirements file because new version (1.15.0) breaks `tensorflow` 2.7.0