### PR TITLE
[Snowflake Dask] Fix snowflake dask requirement

### DIFF
--- a/snowflake_dask/requirements.txt
+++ b/snowflake_dask/requirements.txt
@@ -1,4 +1,3 @@
 bokeh
 snowflake-connector-python[pandas]
 mlrun>=1.1.0
-pyOpenSSL==22.0.0


### PR DESCRIPTION
Removed `pyOpenSSL==22.0.0` requirement that causes dependency loop with mlrun over cryptography package