### PR TITLE
Revert "Feature/speed up pii" for review purpose 

### DIFF
--- a/pii_recognizer/data/config.csv
+++ b/pii_recognizer/data/config.csv
@@ -1,3 +1,0 @@
-input_file,output_file
-data/pii.txt,data/pii_out.txt
-data/letter.txt,data/letter_out.txt

--- a/pii_recognizer/pii_recognizer.py
+++ b/pii_recognizer/pii_recognizer.py
@@ -18,9 +18,7 @@ import os
 import pathlib
 import tempfile
 import warnings
-import pandas as pd
 from collections.abc import Iterable
-from multiprocessing import Pool, cpu_count
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import annotated_text.util as at_util
@@ -851,6 +849,7 @@ def recognize_pii(
     context: mlrun.MLClientCtx,
     input_path: Union[str, pathlib.Path],
     output_path: str,
+    output_suffix: str,
     html_key: str,
     score_threshold: float,
     entities: List[
@@ -870,6 +869,7 @@ def recognize_pii(
     :param context:              The MLRun context. this is needed for log the artifacts.
     :param input_path:           The input path of the text files needs to be analyzied.
     :param output_path:          The output path to store the anonymized text.
+    :param output_suffix:        The surfix of output key for the anonymized text. for example if the input file is pii.txt, the output key is anoymized, the output file name will be pii_anonymized.txt.
     :param html_key:             The html key for the artifact.
     :param score_threshold:      The score threshold to mark the recognition as trusted.
     :param entities:             The list of entities to recognize.
@@ -922,8 +922,6 @@ def recognize_pii(
         try:
             # Load the str from the text file
             text = txt_file.read_text()
-            # TODO maybe the encoding issue if from this function call of tqdm.read_text()
-            # Need to fix it later
             txt_content[str(txt_file)] = text
             # Process the text to recoginze the pii entities in it
             anonymized_text, results = _process(
@@ -958,145 +956,3 @@ def recognize_pii(
         json_res = _get_all_rpt(res_dict, is_full_report)
         return output_path, json_res, errors
     return output_path, errors
-
-
-def _recognize_pii_one_file(
-    input_file: str,
-    output_file: str,
-    score_threshold: float,
-    entities: List[
-        str
-    ] = None,  # List of entities to recognize, default is recognizing all
-    entity_operator_map: dict = None,
-    model: str = None,
-    is_full_text: bool = True,
-) -> Tuple[dict, dict, dict]:
-    """
-    Recognize PII in text and store the anonymized text in the output path. Generate the html with different colors for each entity, json report of the explaination.
-    :param input_file:           The input path of the text files needs to be analyzied.
-    :param output_file:          The output path to store the anonymized text.
-    :param score_threshold:      The score threshold to mark the recognition as trusted.
-    :param entities:             The list of entities to recognize.
-    :param entity_operator_map:  The map of entity to operator (mask, redact, replace, keep, hash, and its params)
-    :param model:                The model to use. Can be "spacy", "flair", "pattern" or "whole".
-    :param is_full_text:         Whether to return the full text or only the masked text.
-
-    :returns: A tuple of:
-        * A dictionary of the text content of the input file
-        * A dictionary of the results of the explaination
-        * A dictionary of errors files that were not processed
-    """
-
-    errors = {}
-    res_dict = {}
-    txt_content = {}
-    # Load the model:
-    try:
-        analyzer = _get_analyzer_engine(model, entities)
-    except Exception as e:
-        errors["model"] = str(e)
-        logger.error(f"Error when get the model: {e}")
-
-    logger.info("Model loaded")
-    try:
-        # Load the str from the text file
-        with open(input_file, "r", encoding="utf-8") as file:
-            text = file.read()
-        txt_content[str(input_file)] = text
-        # Process the text to recoginze the pii entities in it
-        anonymized_text, results = _process(
-            text=text,
-            model=analyzer,
-            entities=entities,
-            entities_operator_map=entity_operator_map,
-            score_threshold=score_threshold,
-            is_full_text=is_full_text,
-        )
-        res_dict[str(input_file)] = results
-        with open(output_file, "w", encoding="utf-8") as f:
-            f.write(anonymized_text)
-
-    except Exception as e:
-        errors[str(txt_file)] = str(e)
-        logger.error(f"Error processing {txt_file}: {e}")
-
-    return res_dict, txt_content, errors
-
-
-def recognize_pii_parallel(
-    context: mlrun.MLClientCtx,
-    config_input_output: str,
-    score_threshold: float,
-    html_key: str,
-    entities: List[str] = None,
-    entity_operator_map: Dict = None,
-    model: str = None,
-    generate_html: bool = True,
-    generate_json: bool = True,
-    is_full_html: bool = True,
-    is_full_text: bool = True,
-    is_full_report: bool = True,
-    num_processes: int = None,
-) -> Tuple[dict, dict]:
-    """Doing a fan-in and fan-out pattern using mutiple processes for cpu node, Since our model is mixed with rule_based and NLP model based. Both Spacy and Flair do not support the cuda GPU natively. For now, we can use all the cores that a CPU offers.
-    :param context:             The MLRun context. this is needed
-    :param config_input_output  csv file which have the input file path and output file path
-    :param score_threshold:     The threshold of the score to recognize the entities
-    :param html_key:            The key of the html report in the context
-    :entities                   List of entities to recognize, default is recognizing all
-    :entity_operator_map        The map of the entities and the operator to use. For example, {"PERSON": "replace", "LOCATION": "mask"}
-    :param model                The model to use. Can be "spacy", "flair", "pattern" or "whole".
-    :param generate_html:       Whether to generate the html report
-    :param generate_json:       Whether to generate the json report
-    :param is_full_html:        Whether to generate the full html report
-    :param is_full_text:        Whether to generate the full text in the html report
-    :param is_full_report:      Whether to generate the full json report
-    :param num_process          The number of process to run in parallel
-
-    :returns: A tuple of:
-        * A json report of the result explaination
-        * A dictionary of errors files that were not processed
-
-    """
-    if num_processes is None:
-        num_processes = cpu_count()
-
-    # Read the CSV into a DataFrame
-    config_df = pd.read_csv(config_input_output)
-
-    # Convert DataFrame rows into a list of tuples, each tuple is arguments for `_recognize_pii_one_file`
-    tasks = [
-        (
-            row["input_file"],
-            row["output_file"],
-            score_threshold,
-            entities,
-            entity_operator_map,
-            model,
-            is_full_text,
-        )
-        for _, row in config_df.iterrows()
-    ]
-    # Create a pool of processes and distribute the tasks
-    with Pool(processes=num_processes) as pool:
-        res = pool.starmap(_recognize_pii_one_file, tasks)
-    # Get the results
-    res_dict = {}
-    txt_content = {}
-    errors = {}
-    for r in res:
-        res_dict.update(r[0])
-        txt_content.update(r[1])
-        errors.update(r[2])
-
-    if generate_html:
-        # Generate the html report
-        html_res = _get_all_html(txt_content, res_dict, is_full_html)
-        # Store the html report in the context
-        arti_html = mlrun.artifacts.Artifact(body=html_res, format="html", key=html_key)
-        context.log_artifact(arti_html)
-    if generate_json:
-        # Generate the json report
-        json_res = _get_all_rpt(res_dict, is_full_report)
-        return json_res, errors
-    return errors

--- a/pii_recognizer/test_pii_recognizer.py
+++ b/pii_recognizer/test_pii_recognizer.py
@@ -17,13 +17,11 @@ import os
 import pytest
 import random
 from faker import Faker
-import mlrun
 from pii_recognizer import (
     _process,
     _get_analyzer_engine,
     _anonymize,
     _annotate,
-    recognize_pii_parallel,
 )
 
 
@@ -213,39 +211,3 @@ def test_only_entities(fake_data):
     analyzer = _get_analyzer_engine(entities=list(ENTITIES.keys())[:5])
     res, results = _process(text, analyzer, score_threshold=0.5)
     assert any(entity in res for entity in ENTITIES.keys())
-
-
-def test_parallel():
-    context = mlrun.get_or_create_ctx("test_parallel")
-    ENTITIES = {
-        "LOCATION": "location",
-        "PERSON": "name",
-        "ORGANIZATION": "organization",
-        "MAC_ADDRESS": "mac_address",
-        "US_BANK_NUMBER": "us_bank_number",
-        "IMEI": "imei",
-        "TITLE": "title",
-        "LICENSE_PLATE": "license_plate",
-        "US_PASSPORT": "us_passport",
-        "CURRENCY": "currency",
-        "ROUTING_NUMBER": "routing_number",
-        "US_ITIN": "us_itin",
-        "US_BANK_NUMBER": "us_bank_number",
-        "AGE": "age",
-        "CREDIT_CARD": "credit_card",
-        "SSN": "ssn",
-        "PHONE": "phone",
-        "EMAIL": "email",
-        "PASSWORD": "password",
-        "SWIFT_CODE": "swift_code",
-    }
-    json_res, erros = recognize_pii_parallel(
-        context=context,
-        config_input_output="data/config.csv",
-        score_threshold=0.5,
-        html_key="test_parallel",
-        entities=list(ENTITIES.keys()),
-        model="whole",
-    )
-
-    assert len(json_res) == 2


### PR DESCRIPTION
Hi Guy. 

Here is the changes in this PR.  Since we still need to build the pipeline with MPI operator. I think maybe it's better to get your feedback sooner than later.
1. `_recognize_pii_one_file` function accepts input_file, output_file to process.
2. `recognize_pii_parallel` function accepts a csv file that each row has the input_file, output_file. it does a fan-in, fan-out pattern with multiple processing. After that, we collect the result to generate whole html and json report for artifact. 
3. I haven't deleted our original function. Just for your reference. 

Please let me know what do you think? Thanks. 