### PR TITLE
[Build] Restrict sphinxcontrib-applehelp in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ isort~=5.7
 sphinx==4.0.2
 sphinx-book-theme==0.3.3
 sphinx-togglebutton==0.3.1
+sphinxcontrib-applehelp<=1.0.7


### PR DESCRIPTION
`sphinxcontrib-applehelp==1.0.8` needs at least Sphinx v5.0; it therefore cannot be built with our sphinx version.