### PR TITLE
[build] Restrict sphinxcontrib-devhelp in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sphinx==4.0.2
 sphinx-book-theme==0.3.3
 sphinx-togglebutton==0.3.1
 sphinxcontrib-applehelp<=1.0.7
+sphinxcontrib.devhelp<=1.0.5


### PR DESCRIPTION
`sphinxcontrib-devhelp==1.0.6` needs at least Sphinx v5.0; it therefore cannot be built with our sphinx version.