### PR TITLE
Bump python:3.6 to python:3.9

### DIFF
--- a/churn_server/function.yaml
+++ b/churn_server/function.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         nuclio.io/generated_by: function generated from /User/functions/churn_server/churn_server.py
     spec:
-      runtime: python:3.6
+      runtime: python:3.9
       handler: churn_server:handler
       env: []
       volumes: []

--- a/concept_drift_streaming/function.yaml
+++ b/concept_drift_streaming/function.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         nuclio.io/generated_by: function generated from /User/test/functions/concept_drift_streaming/concept_drift_streaming.py
     spec:
-      runtime: python:3.6
+      runtime: python:3.9
       handler: concept_drift_streaming:handler
       env: []
       volumes: []

--- a/model_monitoring_stream/function.yaml
+++ b/model_monitoring_stream/function.yaml
@@ -251,7 +251,7 @@ spec:
       annotations:
         nuclio.io/generated_by: function generated from /home/michaell/projects/functions/model_monitoring_stream/model_monitoring_stream.py
     spec:
-      runtime: python:3.6
+      runtime: python:3.9
       handler: model_monitoring_stream:handler
       env: []
       volumes: []

--- a/model_server/function.yaml
+++ b/model_server/function.yaml
@@ -44,7 +44,7 @@ spec:
       - name: MODEL_CLASS
         value: ClassifierModel
       handler: model_server:handler
-      runtime: python:3.6
+      runtime: python:3.9
       volumes: []
   source: ''
   function_kind: serving

--- a/project_runner/function.yaml
+++ b/project_runner/function.yaml
@@ -48,6 +48,6 @@ spec:
         noBaseImagesPull: true
       env: []
       handler: project_runner:handler
-      runtime: python:3.6
+      runtime: python:3.9
       volumes: []
   source: ''

--- a/rnn_serving/function.yaml
+++ b/rnn_serving/function.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         nuclio.io/generated_by: function generated from /User/test/functions/rnn_serving/rnn_serving.py
     spec:
-      runtime: python:3.6
+      runtime: python:3.9
       handler: rnn_serving:handler
       env: []
       volumes: []

--- a/stream_to_parquet/function.yaml
+++ b/stream_to_parquet/function.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         nuclio.io/generated_by: function generated from /User/test/functions/stream_to_parquet/stream_to_parquet.py
     spec:
-      runtime: python:3.6
+      runtime: python:3.9
       handler: stream_to_parquet:handler
       env: []
       volumes: []

--- a/tf1_serving/function.yaml
+++ b/tf1_serving/function.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         nuclio.io/generated_by: function generated from /home/kali/functions/tf1_serving/tf1_serving.py
     spec:
-      runtime: python:3.6
+      runtime: python:3.9
       handler: tf1_serving:handler
       env: []
       volumes: []

--- a/tf2_serving/function.yaml
+++ b/tf2_serving/function.yaml
@@ -46,7 +46,7 @@ spec:
       - name: MODEL_CLASS
         value: TF2Model
       handler: tf2_serving:handler
-      runtime: python:3.6
+      runtime: python:3.9
       volumes: []
   source: ''
   function_kind: serving

--- a/tf2_serving_v2/function.yaml
+++ b/tf2_serving_v2/function.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         nuclio.io/generated_by: function generated from /home/kali/functions/tf2_serving_v2/tf2_serving_v2.py
     spec:
-      runtime: python:3.6
+      runtime: python:3.9
       handler: tf2_serving_v2:handler
       env: []
       volumes: []

--- a/v2_model_server/function.yaml
+++ b/v2_model_server/function.yaml
@@ -70,7 +70,7 @@ spec:
       annotations:
         nuclio.io/generated_by: function generated from /home/michaell/projects/functions/v2_model_server/v2_model_server.py
     spec:
-      runtime: python:3.6
+      runtime: python:3.9
       handler: v2_model_server:handler
       env: []
       volumes: []


### PR DESCRIPTION
Python 3.6 is deprecated in Nuclio, so let's bump all the functions to 3.9