### PR TITLE
Remove `pygit2`

### DIFF
--- a/churn_server/requirements.txt
+++ b/churn_server/requirements.txt
@@ -1,2 +1,1 @@
 wget
-pygit2

--- a/churn_server/test_churn_server.py
+++ b/churn_server/test_churn_server.py
@@ -18,19 +18,19 @@ from mlrun import import_function
 import os.path
 from os import path
 import mlrun
-from pygit2 import Repository
+# from pygit2 import Repository
 
 
 MODEL_PATH = os.path.join(os.path.abspath("./"), "models")
 MODEL = MODEL_PATH + "model.pt"
 
 
-def set_mlrun_hub_url():
-    branch = Repository(".").head.shorthand
-    hub_url = "https://raw.githubusercontent.com/mlrun/functions/{}/churn_server/function.yaml".format(
-        branch
-    )
-    mlrun.mlconf.hub_url = hub_url
+# def set_mlrun_hub_url():
+#     branch = Repository(".").head.shorthand
+#     hub_url = "https://raw.githubusercontent.com/mlrun/functions/{}/churn_server/function.yaml".format(
+#         branch
+#     )
+#     mlrun.mlconf.hub_url = hub_url
 
 
 def download_pretrained_model(model_path):

--- a/xgb_test/requirements.txt
+++ b/xgb_test/requirements.txt
@@ -1,7 +1,6 @@
 pandas
 xgboost
 cloudpickle
-pygit2
 matplotlib
 seaborn
 scikit-plot

--- a/xgb_trainer/requirements.txt
+++ b/xgb_trainer/requirements.txt
@@ -1,7 +1,6 @@
 pandas
 xgboost
 cloudpickle
-pygit2
 scikit-learn==1.0.2
 matplotlib
 seaborn


### PR DESCRIPTION
Remove `pygit2` from the following deprecated functions (EOS):
`churn_server`
`xgb_test`
`xgb_trainer`

Note that these functions will be removed from the hub once MLRun `TestChurn` will be removed

JIRA: https://iguazio.atlassian.net/browse/FHUB-15