### PR TITLE
[HTML] set `navigation_with_keys` to False

### DIFF
--- a/cli/marketplace/conf.template
+++ b/cli/marketplace/conf.template
@@ -93,6 +93,7 @@ html_theme_options = {
     "path_to_docs": "docs",
     "repository_branch": "{{repository_branch}}",
     "single_page": True,
+    "navigation_with_keys": False,
 }
 
 html_title = "{{html_title}}"


### PR DESCRIPTION
Currently, `navigation_with_keys` is set to True. In this PR we change it to False.

https://iguazio.atlassian.net/browse/FHUB-18