### PR TITLE
[Tests] Fix PyYAML loader 

### DIFF
--- a/cli/item_yaml.py
+++ b/cli/item_yaml.py
@@ -40,7 +40,7 @@ def update_functions_yaml(root_directory: str,
         if (inner_dir / item_yaml).exists():
             path = str(inner_dir)+"/"+item_yaml
             stream = open(path, 'r')
-            data = yaml.load(stream)
+            data = yaml.load(stream=stream, Loader=yaml.FullLoader)
             if version:
                 data['version'] = version
             if mlrun_version:

--- a/cli/test_suite.py
+++ b/cli/test_suite.py
@@ -599,7 +599,7 @@ def clean_pipenv(directory: str):
 # load item yaml
 def load_item(path):
     with open(path, 'r') as stream:
-        data = yaml.load(stream)
+        data = yaml.load(stream=stream, Loader=yaml.FullLoader)
     return data
 
 


### PR DESCRIPTION
To prevent failures in the test suite, we need to explicitly define the `PyYAML` loader. This loader defines how YAML files are parsed. 