### PR TITLE
[Vulnerabilities] set `autoescape=True` to avoid cross-site scripting (XSS) attacks

### DIFF
--- a/cli/helpers.py
+++ b/cli/helpers.py
@@ -44,7 +44,7 @@ def render_jinja(
     with open(template_path, "r") as t:
         template_text = t.read()
 
-    template = Template(template_text)
+    template = Template(template_text, autoescape=True)
     rendered = template.render(**data)
 
     with open(output_path, "w+") as out_t:


### PR DESCRIPTION
To address https://codeql.github.com/codeql-query-help/python/py-jinja2-autoescape-false/, in this PR we define the jinja2 template with `autoescape=True` that escapes characters like <, >, &, ", and ' by default, which helps to prevent XSS attacks when generating the HTML pages. 