### PR TITLE
[github workflow] Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,6 @@
 name: Test functions
-
+permissions:
+  contents: read
 on:
   pull_request:
     types: [opened,synchronize]

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -1,5 +1,6 @@
 name: Test all functions, build marketplace
-
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/FHUB-71

fix vulnerability alert (CWE-275) by adding `permissions` section to the workflow yaml files with limitation to read only for the `contents` scope, which in practice means that access to the contents and metadata is set to read only and for the rest of the scopes is set to none (neither read or write)